### PR TITLE
Fix parsing of enum with int const values

### DIFF
--- a/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
+++ b/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
@@ -238,7 +238,6 @@ class ParserActions {
             @Override
             public boolean run(Context context) {
                 ValueStack valueStack = context.getValueStack();
-                IdentifierNode identifier = (IdentifierNode) valueStack.pop();
 
                 Optional<IntConstNode> value;
 
@@ -248,6 +247,7 @@ class ParserActions {
                     value = Optional.empty();
                 }
 
+                IdentifierNode identifier = (IdentifierNode) valueStack.pop();
                 EnumValueNode node = new EnumValueNode(identifier, value);
                 valueStack.push(node);
                 return true;

--- a/src/main/resources/enum.thrift
+++ b/src/main/resources/enum.thrift
@@ -1,0 +1,7 @@
+namespace java com.example
+
+enum EnumType {
+    VALUE1 = 0;
+    VALUE2 = 1;
+    VALUE3 = 2;
+}

--- a/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
+++ b/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
@@ -2,6 +2,8 @@ package com.mitchseymour.thrift.parser;
 
 import static org.junit.Assert.assertTrue;
 import static com.mitchseymour.thrift.parser.ThriftParser.*;
+
+import com.mitchseymour.thrift.parser.ast.Nodes;
 import com.mitchseymour.thrift.parser.ast.Nodes.DocumentNode;
 import java.io.IOException;
 import java.util.Optional;
@@ -22,6 +24,23 @@ public class ThriftParserTest {
         DocumentNode document = parsedDocument.get();
         assert(document.headers.size() > 0);
         assert(document.definitions.size() > 0);
+        System.out.println(document.printTree());
+    }
+
+    @Test
+    public void enumAast() throws IOException {
+        Optional<DocumentNode> parsedDocument = parseThriftFileAst("/enum.thrift");
+        assert(parsedDocument.isPresent());
+        DocumentNode document = parsedDocument.get();
+        assert(document.headers.size() > 0);
+        assert(document.definitions.size() == 1);
+        assert(document.definitions.get(0).type.equals(Nodes.EnumNode.class));
+        final Nodes.EnumNode enumNode = (Nodes.EnumNode) document.definitions.get(0).value;
+        assert(enumNode.values.size() == 3);
+        assert(enumNode.values.get(0).getClass().equals(Nodes.EnumValueNode.class));
+        final Nodes.EnumValueNode enumValueNode = enumNode.values.get(0);
+        assert("VALUE3".equalsIgnoreCase(enumValueNode.identifier.name));
+        assert(enumValueNode.value.map(intConstNode -> intConstNode.value).orElse(-1) == 2);
         System.out.println(document.printTree());
     }
 }


### PR DESCRIPTION
Because an `IntConstNode` has been push on the stack after the enum `Identifier`, and before that fix, the example file included in this patch would produce the following stack:

```
org.parboiled.errors.ParserRuntimeException: Error while parsing action 'Document/ZeroOrMore/Definition/FirstOf/Enum/ZeroOrMore/EnumValue/com.mitchseymour.thrift.parser.ast.ParserActions$16@71bbf57e' at input position (line 5, pos 5):
    VALUE2 = 1;
    ^

java.lang.ClassCastException: com.mitchseymour.thrift.parser.ast.Nodes$IntConstNode cannot be cast to com.mitchseymour.thrift.parser.ast.Nodes$IdentifierNode

	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:366)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.ZeroOrMoreMatcher.match(ZeroOrMoreMatcher.java:39)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.matchers.VarFramingMatcher.match(VarFramingMatcher.java:44)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.FirstOfMatcher.match(FirstOfMatcher.java:41)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.ZeroOrMoreMatcher.match(ZeroOrMoreMatcher.java:39)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.parserunners.BasicParseRunner.run(BasicParseRunner.java:72)
	at org.parboiled.parserunners.ReportingParseRunner.runBasicMatch(ReportingParseRunner.java:86)
	at org.parboiled.parserunners.ReportingParseRunner.run(ReportingParseRunner.java:66)
	at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:81)
	at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:76)
	at com.mitchseymour.thrift.parser.ast.ThriftAst.parseThriftIdl(ThriftAst.java:796)
	at com.mitchseymour.thrift.parser.ThriftParser.applyAst(ThriftParser.java:49)
	at com.mitchseymour.thrift.parser.ThriftParser.parseThriftFileAst(ThriftParser.java:25)
	at com.mitchseymour.thrift.parser.ThriftParserTest.enumAast(ThriftParserTest.java:32)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassCastException: com.mitchseymour.thrift.parser.ast.Nodes$IntConstNode cannot be cast to com.mitchseymour.thrift.parser.ast.Nodes$IdentifierNode
	at com.mitchseymour.thrift.parser.ast.ParserActions$16.run(ParserActions.java:241)
	at org.parboiled.matchers.ActionMatcher.match(ActionMatcher.java:96)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	... 53 more
```