### PR TITLE
Fix structs with spaces and values

### DIFF
--- a/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
+++ b/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
@@ -376,22 +376,23 @@ class ParserActions {
             @Override
             public boolean run(Context context) {
                 ValueStack valueStack = context.getValueStack();
-                IdentifierNode identifier = (IdentifierNode) valueStack.pop();
-                FieldTypeNode fieldType = (FieldTypeNode) valueStack.pop();
 
                 Optional<IntConstNode> id;
                 Optional<ConstValueNode> value;
-
-                if (IntConstNode.class.isInstance(valueStack.peek())) {
-                    id = Optional.of((IntConstNode) valueStack.pop());
-                } else {
-                    id = Optional.empty();
-                }
 
                 if (ConstValueNode.class.isInstance(valueStack.peek())) {
                     value = Optional.of((ConstValueNode) valueStack.pop());
                 } else {
                     value = Optional.empty();
+                }
+
+                IdentifierNode identifier = (IdentifierNode) valueStack.pop();
+                FieldTypeNode fieldType = (FieldTypeNode) valueStack.pop();
+
+                if (IntConstNode.class.isInstance(valueStack.peek())) {
+                    id = Optional.of((IntConstNode) valueStack.pop());
+                } else {
+                    id = Optional.empty();
                 }
 
                 XsdFieldOptionsNode xsdFieldOptions = null; // temporarily disabled

--- a/src/main/java/com/mitchseymour/thrift/parser/ast/ThriftAst.java
+++ b/src/main/java/com/mitchseymour/thrift/parser/ast/ThriftAst.java
@@ -374,7 +374,7 @@ public class ThriftAst extends BaseParser<Object> {
      */
     Rule FieldID() {
         // No direct effect on value stack
-        return Sequence(IntConstant(), ": ");
+        return Sequence(IntConstant(), WhiteSpace(), ": ");
     }
 
     //================================================================================

--- a/src/main/resources/struct.thrift
+++ b/src/main/resources/struct.thrift
@@ -1,0 +1,7 @@
+namespace java com.example
+
+struct StructType {
+    1 : string field1;
+    2 : CustomType field2;
+    3 : optional i64 field3 = -1;
+}

--- a/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
+++ b/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
@@ -28,6 +28,19 @@ public class ThriftParserTest {
     }
 
     @Test
+    public void structAast() throws IOException {
+        Optional<DocumentNode> parsedDocument = parseThriftFileAst("/struct.thrift");
+        assert (parsedDocument.isPresent());
+        DocumentNode document = parsedDocument.get();
+        assert (document.headers.size() > 0);
+        assert (document.definitions.size() == 1);
+        assert(document.definitions.get(0).type.equals(Nodes.StructNode.class));
+        final Nodes.StructNode structNode = (Nodes.StructNode) document.definitions.get(0).value;
+        assert(structNode.fields.size() == 3);
+        System.out.println(document.printTree());
+    }
+
+    @Test
     public void enumAast() throws IOException {
         Optional<DocumentNode> parsedDocument = parseThriftFileAst("/enum.thrift");
         assert(parsedDocument.isPresent());


### PR DESCRIPTION
Structs having a space between the field id and the `:` would not parse.
Also, structs containing fields with values would push an `IntConstNode` on the stack after the struct `Identifier`, and would not be popped in the correct order. The example file included in this patch would produce the following stack:

```
org.parboiled.errors.ParserRuntimeException: Error while parsing action 'Document/ZeroOrMore/Definition/FirstOf/Struct/ZeroOrMore/Field/com.mitchseymour.thrift.parser.ast.ParserActions$22@1786dec2' at input position (line 7, pos 1):
}
^

java.lang.ClassCastException: com.mitchseymour.thrift.parser.ast.Nodes$ConstValueNode cannot be cast to com.mitchseymour.thrift.parser.ast.Nodes$IdentifierNode

	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:366)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.ZeroOrMoreMatcher.match(ZeroOrMoreMatcher.java:39)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.matchers.VarFramingMatcher.match(VarFramingMatcher.java:44)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.FirstOfMatcher.match(FirstOfMatcher.java:41)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.ZeroOrMoreMatcher.match(ZeroOrMoreMatcher.java:39)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.matchers.SequenceMatcher.match(SequenceMatcher.java:46)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	at org.parboiled.parserunners.BasicParseRunner.run(BasicParseRunner.java:72)
	at org.parboiled.parserunners.ReportingParseRunner.runBasicMatch(ReportingParseRunner.java:86)
	at org.parboiled.parserunners.ReportingParseRunner.run(ReportingParseRunner.java:66)
	at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:81)
	at org.parboiled.parserunners.AbstractParseRunner.run(AbstractParseRunner.java:76)
	at com.mitchseymour.thrift.parser.ast.ThriftAst.parseThriftIdl(ThriftAst.java:796)
	at com.mitchseymour.thrift.parser.ThriftParser.applyAst(ThriftParser.java:49)
	at com.mitchseymour.thrift.parser.ThriftParser.parseThriftFileAst(ThriftParser.java:25)
	at com.mitchseymour.thrift.parser.ThriftParserTest.structAast(ThriftParserTest.java:32)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassCastException: com.mitchseymour.thrift.parser.ast.Nodes$ConstValueNode cannot be cast to com.mitchseymour.thrift.parser.ast.Nodes$IdentifierNode
	at com.mitchseymour.thrift.parser.ast.ParserActions$22.run(ParserActions.java:379)
	at org.parboiled.matchers.ActionMatcher.match(ActionMatcher.java:96)
	at org.parboiled.parserunners.BasicParseRunner.match(BasicParseRunner.java:77)
	at org.parboiled.MatcherContext.runMatcher(MatcherContext.java:351)
	... 53 more
```