### PR TITLE
Put enum values in the right order

### DIFF
--- a/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
+++ b/src/main/java/com/mitchseymour/thrift/parser/ast/ParserActions.java
@@ -226,6 +226,7 @@ class ParserActions {
                         break;
                     }
                 }
+                Collections.reverse(values);
                 EnumNode node = new EnumNode(identifier, values);
                 valueStack.push(node);
                 return true;

--- a/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
+++ b/src/test/java/com/mitchseymour/thrift/parser/ThriftParserTest.java
@@ -52,8 +52,8 @@ public class ThriftParserTest {
         assert(enumNode.values.size() == 3);
         assert(enumNode.values.get(0).getClass().equals(Nodes.EnumValueNode.class));
         final Nodes.EnumValueNode enumValueNode = enumNode.values.get(0);
-        assert("VALUE3".equalsIgnoreCase(enumValueNode.identifier.name));
-        assert(enumValueNode.value.map(intConstNode -> intConstNode.value).orElse(-1) == 2);
+        assert("VALUE1".equalsIgnoreCase(enumValueNode.identifier.name));
+        assert(enumValueNode.value.map(intConstNode -> intConstNode.value).orElse(-1) == 0);
         System.out.println(document.printTree());
     }
 }


### PR DESCRIPTION
Reverses the order in which the `EnumValueNode`s are popped from the stack so that they are stored in the AST in the same order as they are declared in the thrift file